### PR TITLE
BUG: eigh vectors fails to converge if `Ci` is np.matrix and not np.array.

### DIFF
--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -1,4 +1,5 @@
 import numpy
+import scipy
 
 ###############################################################
 # Basic Functions
@@ -18,7 +19,7 @@ def sqrtm(Ci):
     :returns: the matrix square root
 
     """
-    D, V = numpy.linalg.eigh(Ci)
+    D, V = scipy.linalg.eigh(Ci)
     D = numpy.matrix(numpy.diag(numpy.sqrt(D)))
     V = numpy.matrix(V)
     Out = numpy.matrix(V * D * V.T)

--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -39,7 +39,7 @@ def logm(Ci):
     :returns: the matrix logarithm
 
     """
-    D, V = numpy.linalg.eigh(Ci)
+    D, V = scipy.linalg.eigh(Ci)
     Out = numpy.dot(numpy.multiply(V, numpy.log(D)), V.T)
     return Out
 
@@ -57,7 +57,7 @@ def expm(Ci):
     :returns: the matrix exponential
 
     """
-    D, V = numpy.linalg.eigh(Ci)
+    D, V = scipy.linalg.eigh(Ci)
     D = numpy.matrix(numpy.diag(numpy.exp(D)))
     V = numpy.matrix(V)
     Out = numpy.matrix(V * D * V.T)
@@ -77,7 +77,7 @@ def invsqrtm(Ci):
     :returns: the inverse matrix square root
 
     """
-    D, V = numpy.linalg.eigh(Ci)
+    D, V = scipy.linalg.eigh(Ci)
     D = numpy.matrix(numpy.diag(1.0 / numpy.sqrt(D)))
     V = numpy.matrix(V)
     Out = numpy.matrix(V * D * V.T)
@@ -98,7 +98,7 @@ def powm(Ci, alpha):
     :returns: the matrix power
 
     """
-    D, V = numpy.linalg.eigh(Ci)
+    D, V = scipy.linalg.eigh(Ci)
     D = numpy.matrix(numpy.diag(D**alpha))
     V = numpy.matrix(V)
     Out = numpy.matrix(V * D * V.T)


### PR DESCRIPTION
I'm trying to pipe some of your code to the [GAT](http://martinos.org/mne/stable/auto_examples/decoding/plot_decoding_time_generalization.html) method - the code optimizes memory and speed for search light computation. However, the eigen values then fail to converge: [here s the gist](https://gist.github.com/kingjr/5c5b3fdcd9fa1cb07e4b)

I'm not sure why it fails in the GAT, but not outside. I suspect it's something to do with the  [cloning](http://scikit-learn.org/stable/modules/generated/sklearn.base.clone.html) of the classifier, but haven't pinpointed the actual source of the bug. The scripts also bugs when several jobs are involved, but this should be handled in a dedicated PR.

Anyway, it seems that the failure to converge can be easily solved by changing scipy.linealg.eig instead of numpy.linealg (or setting `Ci` to a numpy.array instead of a matrix). Do you see any issue in doing so?