### PR TITLE
FIX: scikit-learn LDA import

### DIFF
--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -28,7 +28,7 @@ from pyriemann.estimation import covariances
 from sklearn.cross_validation import cross_val_score, KFold
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
-from sklearn.lda import LDA
+from sklearn.lda import LDA  # XXX has changed since v.17
 
 ###############################################################################
 # Set parameters and read data

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -21,14 +21,12 @@ from mne.decoding import CSP
 
 # pyriemann import
 from pyriemann.classification import MDM, TSclassifier
-from pyriemann.tangentspace import TangentSpace
 from pyriemann.estimation import covariances
 
 # sklearn imports
 from sklearn.cross_validation import cross_val_score, KFold
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
-from sklearn.lda import LDA  # XXX has changed since v.17
 
 ###############################################################################
 # Set parameters and read data
@@ -94,14 +92,14 @@ class_balance = max(class_balance, 1. - class_balance)
 print("Tangent space Classification accuracy: %f / Chance level: %f" %
       (np.mean(scores), class_balance))
 ###############################################################################
-# Classification with CSP + linear discrimant analysis
+# Classification with CSP + logistic regression
 
 # Assemble a classifier
-lda = LDA()
+lr = LogisticRegression()
 csp = CSP(n_components=4, reg='ledoit_wolf', log=True)
 
 
-clf = Pipeline([('CSP', csp), ('LDA', lda)])
+clf = Pipeline([('CSP', csp), ('LogisticRegression', lr)])
 scores = cross_val_score(clf, epochs_data_train, labels, cv=cv, n_jobs=1)
 
 # Printing the results

--- a/pyriemann/tangentspace.py
+++ b/pyriemann/tangentspace.py
@@ -1,10 +1,15 @@
 """Tangent space functions."""
 from .utils.mean import mean_covariance
 from .utils.tangentspace import tangent_space, untangent_space
+from .utils.base import check_version
 
 import numpy
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.lda import LDA
+if check_version('sklearn', '0.17'):
+    from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+else:
+    from sklearn.lda import LDA
+
 
 
 class TangentSpace(BaseEstimator, TransformerMixin):

--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -103,3 +103,34 @@ def powm(Ci, alpha):
     V = numpy.matrix(V)
     Out = numpy.matrix(V * D * V.T)
     return Out
+
+
+def check_version(library, min_version):
+    """Check minimum library version required
+
+    Parameters
+    ----------
+    library : str
+        The library name to import. Must have a ``__version__`` property.
+    min_version : str
+        The minimum version string. Anything that matches
+        ``'(\\d+ | [a-z]+ | \\.)'``
+
+    Returns
+    -------
+    ok : bool
+        True if the library exists with at least the specified version.
+
+    Adapted from MNE-Python: http://github.com/mne-tools/mne-python
+    """
+    from distutils.version import LooseVersion
+    ok = True
+    try:
+        library = __import__(library)
+    except ImportError:
+        ok = False
+    else:
+        this_version = LooseVersion(library.__version__)
+        if this_version < min_version:
+            ok = False
+    return ok


### PR DESCRIPTION
The current sklearn import is outdated, and will be deprecated in .19

This PR checks the sklearn version and import and LDA accordingly.

Also switch the LDA of the `plot_single` example into a LogisticRegression so as to keep it clean.

Note that the cv will be changing from v.18, (they are now in `model_selection`) and have a slighlty different behavior (`for train, test in cv.split()` instead of `for train, test in cv`)

