### PR TITLE
FIX: compatibility with sklearn get_params 

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -28,6 +28,8 @@ v0.2.4 (Unreleased)
 
 - Added Multiclass CSP.
 
+- API: param name changes in `estimations.CospCovariances` to comply to Scikit-Learn.
+
 v0.2.3 (November 2015)
 ----------------------
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -249,8 +249,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         self.fmin = fmin
         self.fmax = fmax
         self.fs = fs
-
-        self._phase_corr = phase_correction
+        self.phase_correction = phase_correction
 
     def fit(self, X, y=None):
         return self

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -244,11 +244,11 @@ class CospCovariances(BaseEstimator, TransformerMixin):
     def __init__(self, window=128, overlap=0.75, fmin=None, fmax=None, fs=None,
                  phase_correction=False):
         """Init."""
-        self._window = _nextpow2(window)
-        self._overlap = overlap
-        self._fmin = fmin
-        self._fmax = fmax
-        self._fs = fs
+        self.window = _nextpow2(window)
+        self.overlap = overlap
+        self.fmin = fmin
+        self.fmax = fmax
+        self.fs = fs
 
         self._phase_corr = phase_correction
 
@@ -261,8 +261,8 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         out = []
 
         for i in range(Nt):
-            S = cospectrum(X[i], window=self._window, overlap=self._overlap,
-                           fmin=self._fmin, fmax=self._fmax, fs=self._fs)
+            S = cospectrum(X[i], window=self.window, overlap=self.overlap,
+                           fmin=self.fmin, fmax=self.fmax, fs=self.fs)
             out.append(S.real)
 
         return numpy.array(out)

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -249,7 +249,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         self.fmin = fmin
         self.fmax = fmax
         self.fs = fs
-        self.phase_correction = phase_correction
+        self.phase_correction = phase_correction  # XXX never used?
 
     def fit(self, X, y=None):
         return self

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -241,15 +241,14 @@ class CospCovariances(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, window=128, overlap=0.75, fmin=None, fmax=None, fs=None,
-                 phase_correction=False):
+    def __init__(self, window=128, overlap=0.75, fmin=None, fmax=None,
+                 fs=None):
         """Init."""
         self.window = _nextpow2(window)
         self.overlap = overlap
         self.fmin = fmin
         self.fmax = fmax
         self.fs = fs
-        self.phase_correction = phase_correction  # XXX never used?
 
     def fit(self, X, y=None):
         return self

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pyriemann.estimation import (Covariances, ERPCovariances,
                                   XdawnCovariances, CospCovariances)
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_equal
 
 
 def test_covariances():
@@ -10,6 +10,7 @@ def test_covariances():
     cov = Covariances()
     cov.fit(x)
     cov.fit_transform(x)
+    assert_equal(cov.get_params(), dict(estimator='scm'))
 
 
 def test_ERPcovariances():
@@ -23,6 +24,8 @@ def test_ERPcovariances():
     # assert raise svd
     assert_raises(TypeError, ERPCovariances, svd='42')
     cov = ERPCovariances(svd=1)
+    assert_equal(cov.get_params(), dict(classes=None, estimator='scm',
+                                        svd=1))
 
 
 def test_Xdawncovariances():
@@ -31,6 +34,9 @@ def test_Xdawncovariances():
     labels = np.array([0, 1]).repeat(5)
     cov = XdawnCovariances()
     cov.fit_transform(x, labels)
+    assert_equal(cov.get_params(), dict(nfilter=4, applyfilters=True,
+                                        classes=None, estimator='scm',
+                                        xdawn_estimator='scm'))
 
 
 def test_Cospcovariances():
@@ -39,3 +45,6 @@ def test_Cospcovariances():
     cov = CospCovariances()
     cov.fit(x)
     cov.fit_transform(x)
+    assert_equal(cov.get_params(), dict(window=128, overlap=0.75, fmin=None,
+                                        fmax=None, fs=None,
+                                        phase_correction=False))

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,37 +1,41 @@
 import numpy as np
-from pyriemann.estimation import Covariances, ERPCovariances, XdawnCovariances, CospCovariances
+from pyriemann.estimation import (Covariances, ERPCovariances,
+                                  XdawnCovariances, CospCovariances)
 from nose.tools import assert_raises
+
 
 def test_covariances():
     """Test fit Covariances"""
-    x = np.random.randn(2,3,100)
+    x = np.random.randn(2, 3, 100)
     cov = Covariances()
     cov.fit(x)
     cov.fit_transform(x)
 
+
 def test_ERPcovariances():
     """Test fit ERPCovariances"""
-    x = np.random.randn(10,3,100)
-    labels = np.array([0,1]).repeat(5)
+    x = np.random.randn(10, 3, 100)
+    labels = np.array([0, 1]).repeat(5)
     cov = ERPCovariances()
-    cov.fit_transform(x,labels)
+    cov.fit_transform(x, labels)
     cov = ERPCovariances(classes=[0])
-    cov.fit_transform(x,labels)
+    cov.fit_transform(x, labels)
     # assert raise svd
-    assert_raises(TypeError,ERPCovariances,svd='42')
+    assert_raises(TypeError, ERPCovariances, svd='42')
     cov = ERPCovariances(svd=1)
 
 
 def test_Xdawncovariances():
     """Test fit ERPCovariances"""
-    x = np.random.randn(10,3,100)
-    labels = np.array([0,1]).repeat(5)
+    x = np.random.randn(10, 3, 100)
+    labels = np.array([0, 1]).repeat(5)
     cov = XdawnCovariances()
-    cov.fit_transform(x,labels)
+    cov.fit_transform(x, labels)
+
 
 def test_Cospcovariances():
     """Test fit CospCovariances"""
-    x = np.random.randn(2,3,1000)
+    x = np.random.randn(2, 3, 1000)
     cov = CospCovariances()
     cov.fit(x)
     cov.fit_transform(x)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -46,5 +46,4 @@ def test_Cospcovariances():
     cov.fit(x)
     cov.fit_transform(x)
     assert_equal(cov.get_params(), dict(window=128, overlap=0.75, fmin=None,
-                                        fmax=None, fs=None,
-                                        phase_correction=False))
+                                        fmax=None, fs=None))


### PR DESCRIPTION
Some of the  covariance classes didn't respect the sklearn `TransformerMixin` syntax where the params have to be stored in attributes with the same names.

Consequently, we couldn't `get_params()` them, and thus cannot `sklearn.base.clone()`, and thus can't use the `mne.decoding.GeneralizationAcrossTime` class.

(Also there are a bunch of params test missing to ensure that the class params are `float`, `int`, `str` etc)