### PR TITLE
FIX: attribute convention ala sklearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For the latest version, you can install the package from the sources using the s
 python setup.py install
 ```
 
-## how to use it
+## How to use it
 
 Most of the functions mimic the scikit-learn API, and therefore can be directly used with sklearn. For example, for cross-validation classification of EEG signal using the MDM algorithm described in [4] , it is easy as :
 
@@ -89,11 +89,15 @@ print(accuracy.mean())
 
 # Testing
 
-If you make a modification, run the test suite before submiting a pull request
+If you make a modification, run the test suite before submitting a pull request
 
 ```
 nosetests
 ```
+
+# Contribution Guidelines
+
+The package aims at adopting the [Scikit-Learn](http://scikit-learn.org/stable/developers/contributing.html#contributing-code) and [MNE-Python](http://martinos.org/mne/stable/contributing.html#general-code-guidelines) conventions as much as possible. See their contribution guidelines before contributing to the repository.
 
 
 # References

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,8 @@ v0.2.4 (Unreleased)
 
 - API: param name changes in `estimations.CospCovariances` to comply to Scikit-Learn.
 
+- API: attributes name changes in most modules to comply to the Scikit-Learn naming convention.
+
 v0.2.3 (November 2015)
 ----------------------
 

--- a/examples/ERP/plot_classify_MEG_mdm.py
+++ b/examples/ERP/plot_classify_MEG_mdm.py
@@ -83,7 +83,7 @@ print(classification_report(labels, pr))
 xd = XdawnCovariances(n_components)
 xd.fit(epochs_data, labels)
 
-evoked.data = xd.Xd.patterns_.T
+evoked.data = xd.Xd_.patterns_.T
 evoked.times = np.arange(evoked.data.shape[0])
 evoked.plot_topomap(times=[0, n_components, 2 * n_components,
                     3 * n_components], ch_type='grad', colorbar=False,

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -117,12 +117,12 @@ mdm.fit(cov_data_train, labels)
 fig, axes = plt.subplots(1, 2, figsize=[8, 4])
 ch_names = [ch.replace('.', '') for ch in epochs.ch_names]
 
-df = pd.DataFrame(data=mdm.covmeans[0], index=ch_names, columns=ch_names)
+df = pd.DataFrame(data=mdm.covmeans_[0], index=ch_names, columns=ch_names)
 g = sns.heatmap(df, ax=axes[0], square=True, cbar=False, xticklabels=2,
                 yticklabels=2)
 g.set_title('Mean covariance - hands')
 
-df = pd.DataFrame(data=mdm.covmeans[1], index=ch_names, columns=ch_names)
+df = pd.DataFrame(data=mdm.covmeans_[1], index=ch_names, columns=ch_names)
 g = sns.heatmap(df, ax=axes[1], square=True, cbar=False, xticklabels=2,
                 yticklabels=2)
 plt.xticks(rotation='vertical')

--- a/examples/stats/plot_oneWay_Manova.py
+++ b/examples/stats/plot_oneWay_Manova.py
@@ -30,9 +30,6 @@ raw_files = [read_raw_edf(f, preload=True, verbose=False)
              for f in eegbci.load_data(subject, runs)]
 raw = concatenate_raws(raw_files)
 
-# strip channel names
-raw.info['ch_names'] = [chn.strip('.') for chn in raw.info['ch_names']]
-
 # Apply band-pass filter
 raw.filter(7., 35., method='iir')
 

--- a/examples/stats/plot_oneWay_Manova.py
+++ b/examples/stats/plot_oneWay_Manova.py
@@ -5,7 +5,6 @@ One Way manova
 
 One way manova to compare Left vs Right.
 """
-import numpy as np
 import matplotlib.pyplot as plt
 
 from mne import Epochs, pick_types
@@ -18,7 +17,7 @@ from pyriemann.stats import PermutationTest
 from pyriemann.estimation import Covariances
 
 ###############################################################################
-## Set parameters and read data
+# Set parameters and read data
 
 # avoid classification of evoked responses by using epochs that start 1s after
 # cue onset.
@@ -27,7 +26,8 @@ event_id = dict(hands=2, feet=3)
 subject = 1
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
-raw_files = [read_raw_edf(f, preload=True,verbose=False) for f in eegbci.load_data(subject, runs) ]
+raw_files = [read_raw_edf(f, preload=True, verbose=False)
+             for f in eegbci.load_data(subject, runs)]
 raw = concatenate_raws(raw_files)
 
 # strip channel names
@@ -43,7 +43,7 @@ picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
 # Read epochs (train will be done only between 1 and 2s)
 # Testing will be done with a running classifier
 epochs = Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
-                baseline=None, preload=True, add_eeg_ref=False,verbose=False)
+                baseline=None, preload=True, add_eeg_ref=False, verbose=False)
 labels = epochs.events[:, -1] - 2
 
 # get epochs

--- a/examples/stats/plot_oneWay_Manova_frequency.py
+++ b/examples/stats/plot_oneWay_Manova_frequency.py
@@ -14,11 +14,11 @@ from mne.io.edf import read_raw_edf
 from mne.datasets import eegbci
 from mne.event import find_events
 
-from pyriemann.stats import PermutationTestTwoWay,PermutationTest
+from pyriemann.stats import PermutationTest
 from pyriemann.estimation import CospCovariances
 
 ###############################################################################
-## Set parameters and read data
+# Set parameters and read data
 
 # avoid classification of evoked responses by using epochs that start 1s after
 # cue onset.
@@ -27,12 +27,9 @@ event_id = dict(hands=2, feet=3)
 subject = 1
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
-raw_files = [read_raw_edf(f, preload=True,verbose=False) for f in eegbci.load_data(subject, runs) ]
+raw_files = [read_raw_edf(f, preload=True, verbose=False)
+             for f in eegbci.load_data(subject, runs)]
 raw = concatenate_raws(raw_files)
-
-# strip channel names
-raw.info['ch_names'] = [chn.strip('.') for chn in raw.info['ch_names']]
-
 
 events = find_events(raw, shortest_event=0, stim_channel='STI 014')
 picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
@@ -41,7 +38,7 @@ picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
 # Read epochs (train will be done only between 1 and 2s)
 # Testing will be done with a running classifier
 epochs = Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
-                baseline=None, preload=True, add_eeg_ref=False,verbose=False)
+                baseline=None, preload=True, add_eeg_ref=False, verbose=False)
 labels = epochs.events[:, -1] - 2
 
 # get epochs
@@ -50,27 +47,28 @@ epochs_data = epochs.get_data()
 # compute cospectral covariance matrices
 fmin = 2.0
 fmax = 40.0
-cosp = CospCovariances(window=128,overlap=0.98,fmin=fmin,fmax=fmax,fs = 160.0)
-covmats = cosp.fit_transform(epochs_data[:,::4,:])
+cosp = CospCovariances(window=128, overlap=0.98, fmin=fmin, fmax=fmax,
+                       fs=160.0)
+covmats = cosp.fit_transform(epochs_data[:, ::4, :])
 
 fr = np.fft.fftfreq(128)[0:64]*160
-fr = fr[(fr>=fmin) & (fr<=fmax)]
+fr = fr[(fr >= fmin) & (fr <= fmax)]
 
 pv = []
 Fv = []
 # For each frequency bin, estimate the stats
 for i in range(covmats.shape[3]):
     p_test = PermutationTest(5000)
-    p,F = p_test.test(covmats[:, :, :, i], labels)
+    p, F = p_test.test(covmats[:, :, :, i], labels)
     print(p_test.summary())
     pv.append(p)
     Fv.append(F[0])
 
-plot(fr,Fv,lw=2)
+plot(fr, Fv, lw=2)
 plt.xlabel('Frequency')
 plt.ylabel('F-value')
 
-significant = np.array(pv)<0.001
+significant = np.array(pv) < 0.001
 plot(fr, significant, 'r', lw=2)
 plt.legend(['F-value', 'p<0.001'])
 plt.grid()

--- a/examples/stats/plot_oneWay_Manova_time.py
+++ b/examples/stats/plot_oneWay_Manova_time.py
@@ -14,11 +14,11 @@ from mne.io.edf import read_raw_edf
 from mne.datasets import eegbci
 from mne.event import find_events
 
-from pyriemann.stats import PermutationTestTwoWay,PermutationTest
+from pyriemann.stats import PermutationTest
 from pyriemann.estimation import Covariances
 
 ###############################################################################
-## Set parameters and read data
+# Set parameters and read data
 
 # avoid classification of evoked responses by using epochs that start 1s after
 # cue onset.
@@ -27,23 +27,18 @@ event_id = dict(hands=2, feet=3)
 subject = 1
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
-raw_files = [read_raw_edf(f, preload=True,verbose=False) for f in eegbci.load_data(subject, runs) ]
+raw_files = [read_raw_edf(f, preload=True, verbose=False)
+             for f in eegbci.load_data(subject, runs)]
 raw = concatenate_raws(raw_files)
-
-# strip channel names
-raw.info['ch_names'] = [chn.strip('.') for chn in raw.info['ch_names']]
-
-
-
 events = find_events(raw, shortest_event=0, stim_channel='STI 014')
 picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
                    exclude='bads')
 
-raw.filter(7., 35., method='iir',picks=picks)
+raw.filter(7., 35., method='iir', picks=picks)
 
 
 epochs = Epochs(raw, events, event_id, tmin, tmax, proj=True, picks=picks,
-                baseline=None, preload=True, add_eeg_ref=False,verbose=False)
+                baseline=None, preload=True, add_eeg_ref=False, verbose=False)
 labels = epochs.events[:, -1] - 2
 
 # get epochs
@@ -57,27 +52,27 @@ Fs = 160
 window = 2*Fs
 Nwindow = 20
 Ns = epochs_data.shape[2]
-step = int((Ns-window)/Nwindow )
-time_bins = range(0,Ns-window,step)
+step = int((Ns-window)/Nwindow)
+time_bins = range(0, Ns-window, step)
 
 pv = []
 Fv = []
 # For each frequency bin, estimate the stats
 for t in time_bins:
-    covmats = covest.fit_transform(epochs_data[:,::1,t:(t+window)])
+    covmats = covest.fit_transform(epochs_data[:, ::1, t:(t+window)])
     p_test = PermutationTest(5000)
-    p,F = p_test.test(covmats,labels)
+    p, F = p_test.test(covmats, labels)
     print(p_test.summary())
     pv.append(p)
     Fv.append(F[0])
 
 time = np.array(time_bins)/float(Fs) + tmin
-plot(time,Fv,lw=2)
+plot(time, Fv, lw=2)
 plt.xlabel('Time')
 plt.ylabel('F-value')
 
-significant = np.array(pv)<0.001
-plot(time,significant,'r',lw=2)
-plt.legend(['F-value','p<0.001'])
+significant = np.array(pv) < 0.001
+plot(time, significant, 'r', lw=2)
+plt.legend(['F-value', 'p<0.001'])
 plt.grid()
 plt.show()

--- a/examples/stats/plot_oneWay_Manova_time.py
+++ b/examples/stats/plot_oneWay_Manova_time.py
@@ -30,6 +30,7 @@ runs = [6, 10, 14]  # motor imagery: hands vs feet
 raw_files = [read_raw_edf(f, preload=True, verbose=False)
              for f in eegbci.load_data(subject, runs)]
 raw = concatenate_raws(raw_files)
+
 events = find_events(raw, shortest_event=0, stim_channel='STI 014')
 picks = pick_types(raw.info, meg=False, eeg=True, stim=False, eog=False,
                    exclude='bads')

--- a/pyriemann/channelselection.py
+++ b/pyriemann/channelselection.py
@@ -37,9 +37,9 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    covmeans : list
+    covmeans_ : list
         the class centroids.
-    dist : list
+    dist_ : list
         list of distance at each interation.
 
     See Also
@@ -58,9 +58,7 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
         """Init."""
         self.nelec = nelec
         self.metric = metric
-        self.subelec = None
         self.n_jobs = n_jobs
-        self.dist = []
 
     def fit(self, X, y=None, sample_weight=None):
         """Find the optimal subset of electrodes.
@@ -82,26 +80,27 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
         """
         mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
         mdm.fit(X, y, sample_weight=sample_weight)
-        self.covmeans = mdm.covmeans
+        self.covmeans_ = mdm.covmeans_
 
-        Ne, _ = self.covmeans[0].shape
+        Ne, _ = self.covmeans_[0].shape
 
-        self.subelec = range(0, Ne, 1)
-        while (len(self.subelec)) > self.nelec:
-            di = numpy.zeros((len(self.subelec), 1))
-            for idx in range(len(self.subelec)):
-                sub = self.subelec[:]
+        self.dist_ = []
+        self.subelec_ = range(0, Ne, 1)
+        while (len(self.subelec_)) > self.nelec:
+            di = numpy.zeros((len(self.subelec_), 1))
+            for idx in range(len(self.subelec_)):
+                sub = self.subelec_[:]
                 sub.pop(idx)
                 di[idx] = 0
-                for i in range(len(self.covmeans)):
-                    for j in range(i + 1, len(self.covmeans)):
-                        di[idx] += distance(self.covmeans[i][:, sub][sub, :],
-                                            self.covmeans[j][:, sub][sub, :],
+                for i in range(len(self.covmeans_)):
+                    for j in range(i + 1, len(self.covmeans_)):
+                        di[idx] += distance(self.covmeans_[i][:, sub][sub, :],
+                                            self.covmeans_[j][:, sub][sub, :],
                                             metric=mdm.metric_dist)
             # print di
             torm = di.argmax()
-            self.dist.append(di.max())
-            self.subelec.pop(torm)
+            self.dist_.append(di.max())
+            self.subelec_.pop(torm)
         return self
 
     def transform(self, X):
@@ -117,6 +116,6 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
         covs : ndarray, shape (n_trials, n_elec, n_elec)
             The covariances matrices after reduction of the number of channels.
         """
-        if self.subelec is None:
-            self.subelec = range(0, X.shape[1], 1)
-        return X[:, self.subelec, :][:, :, self.subelec]
+        if self.subelec_ is None:
+            self.subelec_ = range(0, X.shape[1], 1)
+        return X[:, self.subelec_, :][:, :, self.subelec_]

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -135,7 +135,6 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         self.classes = classes
         self.estimator = estimator
         self.svd = svd
-        self.P = None
 
         if svd is not None:
             if not isinstance(svd, int):
@@ -163,7 +162,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         else:
             classes = numpy.unique(y)
 
-        self.P = []
+        self.P_ = []
         for c in classes:
             # Prototyped responce for each class
             P = numpy.mean(X[y == c, :, :], axis=0)
@@ -173,9 +172,9 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
                 U, s, V = numpy.linalg.svd(P)
                 P = numpy.dot(U[:, 0:self.svd].T, P)
 
-            self.P.append(P)
+            self.P_.append(P)
 
-        self.P = numpy.concatenate(self.P, axis=0)
+        self.P_ = numpy.concatenate(self.P_, axis=0)
         return self
 
     def transform(self, X):
@@ -193,7 +192,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
             of covmats equal to n_channels * (n_classes + 1) in case svd is
             None and equal to n_channels + n_classes * svd otherwise.
         """
-        covmats = covariances_EP(X, self.P, estimator=self.estimator)
+        covmats = covariances_EP(X, self.P_, estimator=self.estimator)
         return covmats
 
 
@@ -214,17 +213,17 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         self.nfilter = nfilter
 
     def fit(self, X, y):
-        self.Xd = Xdawn(nfilter=self.nfilter, classes=self.classes,
-                        estimator=self.xdawn_estimator)
-        self.Xd.fit(X, y)
-        self.P = self.Xd.evokeds_
+        self.Xd_ = Xdawn(nfilter=self.nfilter, classes=self.classes,
+                         estimator=self.xdawn_estimator)
+        self.Xd_.fit(X, y)
+        self.P_ = self.Xd_.evokeds_
         return self
 
     def transform(self, X):
         if self.applyfilters:
-            X = self.Xd.transform(X)
+            X = self.Xd_.transform(X)
 
-        covmats = covariances_EP(X, self.P, estimator=self.estimator)
+        covmats = covariances_EP(X, self.P_, estimator=self.estimator)
         return covmats
 
     def fit_transform(self, X, y):

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -79,8 +79,8 @@ class Xdawn(BaseEstimator, TransformerMixin):
         """
         Nt, Ne, Ns = X.shape
 
-        if self.classes is None:
-            self.classes = numpy.unique(y)
+        self.classes_ = (numpy.unique(y) if self.classes is None else
+                         self.classes)
 
         # FIXME : too many reshape operation
         tmp = X.transpose((1, 2, 0))
@@ -89,7 +89,7 @@ class Xdawn(BaseEstimator, TransformerMixin):
         self.evokeds_ = []
         self.filters_ = []
         self.patterns_ = []
-        for c in self.classes:
+        for c in self.classes_:
             # Prototyped responce for each class
             P = numpy.mean(X[y == c, :, :], axis=0)
 
@@ -182,8 +182,6 @@ class CSP(BaseEstimator, TransformerMixin):
         """Init."""
         self.nfilter = nfilter
         self.metric = metric
-        self.filters_ = None
-        self.patterns_ = None
 
     def fit(self, X, y):
         """Train CSP spatial filters.

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -67,22 +67,22 @@ class SeparabilityIndex(BaseEstimator):
     def fit(self, X, y=None):
         if self.estimator is not None:
             X = self.estimator.fit_transform(X, y)
-        self.pairs = RiemannDistanceMetric(self.metric).pairwise(X)
+        self.pairs_ = RiemannDistanceMetric(self.metric).pairwise(X)
         return self
 
     def score(self, y):
         groups = numpy.unique(y)
         a = len(groups)
         Ntx = len(y)
-        self.a = a
-        self.Ntx = Ntx
-        self._SST = (self.pairs**2).sum() / (2 * Ntx)
+        self.a_ = a
+        self.Ntx_ = Ntx
+        self._SST = (self.pairs_**2).sum() / (2 * Ntx)
         pattern = numpy.zeros((Ntx, Ntx))
         for g in groups:
             pattern += numpy.outer(y == g, y == g) / \
                 (numpy.float(numpy.sum(y == g)))
 
-        self._SSW = ((self.pairs**2) * (pattern)).sum() / 2
+        self._SSW = ((self.pairs_**2) * (pattern)).sum() / 2
 
         self._SSA = self._SST - self._SSW
 
@@ -99,7 +99,7 @@ class SeparabilityIndexTwoFactor(BaseEstimator):
         self.metric = 'riemann'
 
     def fit(self, X, y=None):
-        self.pairs = RiemannDistanceMetric(self.metric).pairwise(X)
+        self.pairs_ = RiemannDistanceMetric(self.metric).pairwise(X)
         return self
 
     def score(self, fact1, fact2):
@@ -109,10 +109,10 @@ class SeparabilityIndexTwoFactor(BaseEstimator):
         a1 = len(groups1)
         a2 = len(groups2)
         Ntx = len(fact1)
-        self.a1 = a1
-        self.a2 = a2
-        self.Ntx = Ntx
-        self._SST = (self.pairs**2).sum() / (2 * Ntx)
+        self.a1_ = a1
+        self.a2_ = a2
+        self.Ntx_ = Ntx
+        self._SST = (self.pairs_**2).sum() / (2 * Ntx)
 
         # first factor
         pattern = numpy.zeros((Ntx, Ntx))
@@ -121,7 +121,7 @@ class SeparabilityIndexTwoFactor(BaseEstimator):
             pattern += numpy.outer(y == g, y == g) / \
                 (numpy.float(numpy.sum(y == g)))
 
-        self._SSW1 = ((self.pairs**2) * (pattern)).sum() / 2
+        self._SSW1 = ((self.pairs_**2) * (pattern)).sum() / 2
 
         # second factor
         pattern = numpy.zeros((Ntx, Ntx))
@@ -130,7 +130,7 @@ class SeparabilityIndexTwoFactor(BaseEstimator):
             pattern += numpy.outer(y == g, y == g) / \
                 (numpy.float(numpy.sum(y == g)))
 
-        self._SSW2 = ((self.pairs**2) * (pattern)).sum() / 2
+        self._SSW2 = ((self.pairs_**2) * (pattern)).sum() / 2
 
         # Co factor
         pattern = numpy.zeros((Ntx, Ntx))
@@ -140,19 +140,19 @@ class SeparabilityIndexTwoFactor(BaseEstimator):
                 pattern += numpy.outer(truc, truc) / \
                     (numpy.float(numpy.sum(truc)))
 
-        self._SSi = ((self.pairs**2) * (pattern)).sum() / 2
+        self._SSi = ((self.pairs_**2) * (pattern)).sum() / 2
 
-        #self._SS1 =  self._SSW2 - self._SSi
-        #self._SS2 =  self._SSW1 - self._SSi
+        # self._SS1 =  self._SSW2 - self._SSi
+        # self._SS2 =  self._SSW1 - self._SSi
 
         self._SS1 = self._SST - self._SSW1
         self._SS2 = self._SST - self._SSW2
 
-        #self._SSR = self._SST - self._SS1 - self._SS2
+        # self._SSR = self._SST - self._SS1 - self._SS2
         self._SSR = self._SSi
 
         self._SS12 = self._SST - self._SS1 - self._SS2 - self._SSR
-        #self._SS12 = self._SST -self._SSW2  -(self._SSR - self._SSi)
+        # self._SS12 = self._SST -self._SSW2  -(self._SSR - self._SSi)
 
         self._F1 = (self._SS1 / (a1 - 1)) / (self._SSR / (Ntx - a1 * a2))
         self._F2 = (self._SS2 / (a2 - 1)) / (self._SSR / (Ntx - a1 * a2))
@@ -182,7 +182,7 @@ class PermutationTest(BaseEstimator):
         if self.fit_perms is False:
             self.SepIndex.fit(X, y)
         Npe = multiset_perm_number(y)
-        self.F = numpy.zeros(numpy.min([self.n_perms, Npe]) + 1)
+        self.F_ = numpy.zeros(numpy.min([self.n_perms, Npe]) + 1)
         if Npe <= self.n_perms:
             print("Warning, number of unique permutations : %d" % Npe)
             perms = unique_permutations(y)
@@ -190,7 +190,7 @@ class PermutationTest(BaseEstimator):
                 # if fit_perms is true
                 if self.fit_perms is True:
                     self.SepIndex.fit(X, y)
-                self.F[i + 1] = self.SepIndex.score(p)
+                self.F_[i + 1] = self.SepIndex.score(p)
         else:
             for i in range(self.n_perms):
                 perms = numpy.random.permutation(y)
@@ -198,24 +198,25 @@ class PermutationTest(BaseEstimator):
                 # if fit_perms is true
                 if self.fit_perms is True:
                     self.SepIndex.fit(X, y)
-                self.F[i + 1] = self.SepIndex.score(perms)
+                self.F_[i + 1] = self.SepIndex.score(perms)
 
-        self.F[0] = self.SepIndex.score(y)
+        self.F_[0] = self.SepIndex.score(y)
 
-        self.p_value = (self.F[0] <= self.F).sum() / numpy.float(len(self.F))
+        self.p_value_ = ((self.F_[0] <= self.F_).sum() /
+                         numpy.float(len(self.F_)))
 
-        return self.p_value, self.F
+        return self.p_value_, self.F_
 
     def summary(self):
         sep = self.SepIndex
-        a = sep.a
-        Ntx = sep.Ntx
+        a = sep.a_
+        Ntx = sep.Ntx_
 
         df = [(a - 1), Ntx - a, Ntx - 1]
         SS = [sep._SSA, sep._SSW, sep._SST]
         MS = numpy.array(SS) / numpy.array(df)
-        F = [self.F[0], numpy.nan, numpy.nan]
-        p = [self.p_value, numpy.nan, numpy.nan]
+        F = [self.F_[0], numpy.nan, numpy.nan]
+        p = [self.p_value_, numpy.nan, numpy.nan]
 
         cols = ['df', 'SS', 'MS', 'F', 'p-value']
         index = ['Labels', 'Residual', 'Total']
@@ -226,8 +227,8 @@ class PermutationTest(BaseEstimator):
         return res
 
     def plot(self, nbins=100, range=None):
-        plt.plot([self.F[0], self.F[0]], [0, 100], '--r', lw=2)
-        h = plt.hist(self.F, nbins, range)
+        plt.plot([self.F_[0], self.F_[0]], [0, 100], '--r', lw=2)
+        h = plt.hist(self.F_, nbins, range)
         plt.xlabel('F-value')
         plt.ylabel('Count')
         plt.grid()
@@ -251,39 +252,39 @@ class PermutationTestTwoWay(BaseEstimator):
     def test(self, X, factor1, factor2, names=None):
         numpy.random.seed(self.random_state)
         self.SepIndex.fit(X)
-        self.names = names
+        self.names_ = names
 
-        self.F = numpy.zeros((self.n_perms + 1, 3))
+        self.F_ = numpy.zeros((self.n_perms + 1, 3))
         for i in range(self.n_perms):
-            self.F[
+            self.F_[
                 i + 1,
                 :] = self.SepIndex.score(
                 numpy.random.permutation(factor1),
                 numpy.random.permutation(factor2))
 
-        self.F[0, :] = self.SepIndex.score(factor1, factor2)
+        self.F_[0, :] = self.SepIndex.score(factor1, factor2)
 
-        self.p_value = (self.F[0, :] <= self.F).sum(
+        self.p_value_ = (self.F_[0, :] <= self.F_).sum(
             axis=0) / numpy.float(self.n_perms)
 
-        return self.p_value, self.F
+        return self.p_value_, self.F_
 
     def summary(self):
         sep = self.SepIndex
-        Ntx = sep.Ntx
+        Ntx = sep.Ntx_
 
-        df = [sep.a1 - 1, sep.a2 - 1,
-              (sep.a1 - 1) * (sep.a2 - 1), Ntx - sep.a1 * sep.a2, Ntx - 1]
+        df = [sep.a1_ - 1, sep.a2_ - 1,
+              (sep.a1_ - 1) * (sep.a2_ - 1), Ntx - sep.a1_ * sep.a2_, Ntx - 1]
         SS = [sep._SS1, sep._SS2, sep._SS12, sep._SSR, sep._SST]
         MS = numpy.array(SS) / numpy.array(df)
-        F = [self.F[0, 0], self.F[0, 1], self.F[0, 2], numpy.nan, numpy.nan]
-        p = [self.p_value[0], self.p_value[1],
-             self.p_value[2], numpy.nan, numpy.nan]
+        F = [self.F_[0, 0], self.F_[0, 1], self.F_[0, 2], numpy.nan, numpy.nan]
+        p = [self.p_value_[0], self.p_value_[1],
+             self.p_value_[2], numpy.nan, numpy.nan]
 
         cols = ['df', 'sum_sq', 'mean_sq', 'F', 'PR(>F)']
-        if self.names is not None:
-            index = [self.names[0], self.names[1], self.names[
-                0] + ':' + self.names[1], 'Residual', 'Total']
+        if self.names_ is not None:
+            index = [self.names_[0], self.names_[1], self.names_[
+                0] + ':' + self.names_[1], 'Residual', 'Total']
         else:
             index = ['Fact1', 'Fact2', 'Fact1:Fact2', 'Residual', 'Total']
 
@@ -292,13 +293,13 @@ class PermutationTestTwoWay(BaseEstimator):
         res = pandas.DataFrame(data, index=index, columns=cols)
         return res
 
-    def plot(self,nbins=100,plt_range=None):
+    def plot(self, nbins=100, plt_range=None):
         h = None
         for i in range(3):
             plt.subplot(3, 1, i + 1)
-            if not numpy.isnan(self.F[0, i]):
-                h = plt.hist(self.F[:, i], nbins,plt_range)
-                plt.plot([self.F[0, i], self.F[0, i]], [0, 100], '--r', lw=2)
+            if not numpy.isnan(self.F_[0, i]):
+                h = plt.hist(self.F_[:, i], nbins, plt_range)
+                plt.plot([self.F_[0, i], self.F_[0, i]], [0, 100], '--r', lw=2)
                 plt.xlabel('F-value')
                 plt.ylabel('Count')
                 plt.grid()


### PR DESCRIPTION
sklearn naming convention is to have init params given by the subject without a `_` at the end and attributes created by the method with a `_`.

e.g.
```
myclass = MyClass(foo=1)
myclass.foo
myclass.fit()
myclass.bar_
```

That's a lot of changes, some of which are backward incompatible, but I think it's generally safer to stick to their naming convention.