### PR TITLE
ENH: allow precomputed baseline covariance

### DIFF
--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -206,17 +206,21 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, nfilter=4, applyfilters=True, classes=None,
-                 estimator='scm', xdawn_estimator='scm'):
+                 estimator='scm', xdawn_estimator='scm', baseline_cov=None):
         """Init."""
         self.applyfilters = applyfilters
         self.estimator = estimator
         self.xdawn_estimator = xdawn_estimator
         self.classes = classes
         self.nfilter = nfilter
+        self.baseline_cov = baseline_cov
 
     def fit(self, X, y):
+        # FIXME self.Xd should be init at XdawnCovariances.__init__ and be
+        # replaced as param not attribute
         self.Xd_ = Xdawn(nfilter=self.nfilter, classes=self.classes,
-                         estimator=self.xdawn_estimator)
+                         estimator=self.xdawn_estimator,
+                         baseline_cov=self.baseline_cov)
         self.Xd_.fit(X, y)
         self.P_ = self.Xd_.evokeds_
         return self

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -216,8 +216,6 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         self.baseline_cov = baseline_cov
 
     def fit(self, X, y):
-        # FIXME self.Xd should be init at XdawnCovariances.__init__ and be
-        # replaced as param not attribute
         self.Xd_ = Xdawn(nfilter=self.nfilter, classes=self.classes,
                          estimator=self.xdawn_estimator,
                          baseline_cov=self.baseline_cov)

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -28,7 +28,8 @@ class Xdawn(BaseEstimator, TransformerMixin):
         classes will be accounted.
     estimator : str (default 'scm')
         covariance matrix estimator. For regularization consider 'lwf' or 'oas'
-
+    Cx : array, shape(n_chan, n_chan)
+        Precomputed covariance matrix.
     Attributes
     ----------
     filters_ : ndarray
@@ -56,11 +57,12 @@ class Xdawn(BaseEstimator, TransformerMixin):
     2011 19th European (pp. 1382-1386). IEEE.
     """
 
-    def __init__(self, nfilter=4, classes=None, estimator='scm'):
+    def __init__(self, nfilter=4, classes=None, estimator='scm', Cx=None):
         """Init."""
         self.nfilter = nfilter
         self.classes = classes
         self.estimator = _check_est(estimator)
+        self.Cx = Cx
 
     def fit(self, X, y):
         """Train xdawn spatial filters.
@@ -83,8 +85,10 @@ class Xdawn(BaseEstimator, TransformerMixin):
                          self.classes)
 
         # FIXME : too many reshape operation
-        tmp = X.transpose((1, 2, 0))
-        Cx = numpy.matrix(self.estimator(tmp.reshape(Ne, Ns * Nt)))
+        Cx = self.Cx
+        if Cx is None:
+            tmp = X.transpose((1, 2, 0))
+            Cx = numpy.matrix(self.estimator(tmp.reshape(Ne, Ns * Nt)))
 
         self.evokeds_ = []
         self.filters_ = []

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -28,8 +28,9 @@ class Xdawn(BaseEstimator, TransformerMixin):
         classes will be accounted.
     estimator : str (default 'scm')
         covariance matrix estimator. For regularization consider 'lwf' or 'oas'
-    Cx : array, shape(n_chan, n_chan)
-        Precomputed covariance matrix.
+    baseline_cov : array, shape(n_chan, n_chan) | None (default)
+        Covariance matrix to which the average signals are compared. If None,
+        the baseline covariance is computed across all trials and time samples.
     Attributes
     ----------
     filters_ : ndarray
@@ -57,12 +58,13 @@ class Xdawn(BaseEstimator, TransformerMixin):
     2011 19th European (pp. 1382-1386). IEEE.
     """
 
-    def __init__(self, nfilter=4, classes=None, estimator='scm', Cx=None):
+    def __init__(self, nfilter=4, classes=None, estimator='scm',
+                 baseline_cov=None):
         """Init."""
         self.nfilter = nfilter
         self.classes = classes
         self.estimator = _check_est(estimator)
-        self.Cx = Cx
+        self.baseline_cov = baseline_cov
 
     def fit(self, X, y):
         """Train xdawn spatial filters.
@@ -84,9 +86,9 @@ class Xdawn(BaseEstimator, TransformerMixin):
         self.classes_ = (numpy.unique(y) if self.classes is None else
                          self.classes)
 
-        # FIXME : too many reshape operation
-        Cx = self.Cx
+        Cx = self.baseline_cov
         if Cx is None:
+            # FIXME : too many reshape operation
             tmp = X.transpose((1, 2, 0))
             Cx = numpy.matrix(self.estimator(tmp.reshape(Ne, Ns * Nt)))
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -36,7 +36,8 @@ def test_Xdawncovariances():
     cov.fit_transform(x, labels)
     assert_equal(cov.get_params(), dict(nfilter=4, applyfilters=True,
                                         classes=None, estimator='scm',
-                                        xdawn_estimator='scm'))
+                                        xdawn_estimator='scm',
+                                        baseline_cov=None))
 
 
 def test_Cospcovariances():

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -1,9 +1,11 @@
 import numpy as np
 from pyriemann.spatialfilters import Xdawn
 
+
 def test_Xdawn_init():
     """Test init of Xdawn"""
     xd = Xdawn()
+
 
 def test_Xdawn_fit():
     """Test Fit of Xdawn"""
@@ -12,10 +14,21 @@ def test_Xdawn_fit():
     xd = Xdawn()
     xd.fit(x, labels)
 
+
 def test_Xdawn_transform():
     """Test transform of Xdawn"""
     x = np.random.randn(100, 3, 10)
     labels = np.array([0, 1]).repeat(50)
     xd = Xdawn()
+    xd.fit(x, labels)
+    xd.transform(x)
+
+
+def test_Xdawn_Cx():
+    """Test cov precomputation"""
+    x = np.random.randn(100, 3, 10)
+    labels = np.array([0, 1]).repeat(50)
+    Cx = np.identity(3)
+    xd = Xdawn(Cx=Cx)
     xd.fit(x, labels)
     xd.transform(x)

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -24,11 +24,11 @@ def test_Xdawn_transform():
     xd.transform(x)
 
 
-def test_Xdawn_Cx():
+def test_Xdawn_baselinecov():
     """Test cov precomputation"""
     x = np.random.randn(100, 3, 10)
     labels = np.array([0, 1]).repeat(50)
-    Cx = np.identity(3)
-    xd = Xdawn(Cx=Cx)
+    baseline_cov = np.identity(3)
+    xd = Xdawn(baseline_cov=baseline_cov)
     xd.fit(x, labels)
     xd.transform(x)


### PR DESCRIPTION
Here is what I was suggesting to compute the "baseline" cov with unlabeled data.

LTKWYT