### PR TITLE
ENH: handle flat channels in Xdawn

### DIFF
--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -1,34 +1,39 @@
+from nose.tools import assert_true, assert_raises
 import numpy as np
 from pyriemann.spatialfilters import Xdawn
+from pyriemann.utils.covariance import _scm
 
 
-def test_Xdawn_init():
-    """Test init of Xdawn"""
+def test_Xdawn():
+    """Test Xdawn"""
+    X = np.random.randn(100, 3, 10)
+    y = np.array([0, 1]).repeat(50)
     xd = Xdawn()
+    xd.fit(X, y)
+    xd.transform(X)
 
+    # 2. Test fit and transform Xdawn when the baseline covariance is
+    # precomputed
+    Cx = _scm(X.transpose(1, 2, 0).reshape(3, -1))
+    # Error if baseline_cov isn't square matrix
+    assert_raises(ValueError, Xdawn, baseline_cov='foo')
 
-def test_Xdawn_fit():
-    """Test Fit of Xdawn"""
-    x = np.random.randn(100, 3, 10)
-    labels = np.array([0, 1]).repeat(50)
-    xd = Xdawn()
-    xd.fit(x, labels)
+    Xt = Xdawn().fit_transform(X, y)
+    # Error if baseline_cov doesn't have the same dimensionality as X
+    assert_raises(ValueError, Xdawn(baseline_cov=Cx[:1, :1]).fit, X, y)
+    # Same values if precomputed on identical data
+    Xt_bsl = Xdawn(baseline_cov=Cx).fit_transform(X, y)
+    np.testing.assert_array_equal(Xt, Xt_bsl)
+    # Different values if precomputed on different data
+    Cx = _scm(np.random.rand(3, 20))
+    Xt_bsl = Xdawn(baseline_cov=Cx).fit_transform(X, y)
+    assert_true(np.sum((Xt - Xt_bsl) ** 2))
 
-
-def test_Xdawn_transform():
-    """Test transform of Xdawn"""
-    x = np.random.randn(100, 3, 10)
-    labels = np.array([0, 1]).repeat(50)
-    xd = Xdawn()
-    xd.fit(x, labels)
-    xd.transform(x)
-
-
-def test_Xdawn_baselinecov():
-    """Test cov precomputation"""
-    x = np.random.randn(100, 3, 10)
-    labels = np.array([0, 1]).repeat(50)
-    baseline_cov = np.identity(3)
-    xd = Xdawn(baseline_cov=baseline_cov)
-    xd.fit(x, labels)
-    xd.transform(x)
+    # 3. Test fit and transform Xdawn when some channels are flat
+    X[:, 2, :] = 999  # half of the sensors are flat
+    Xt = Xdawn().fit_transform(X, y)
+    assert_true(np.sum(Xt ** 2) != 0)
+    # check when baseline covariance doesn't have bad channels
+    Cx = _scm(np.random.rand(3, 20))
+    Xt = Xdawn(baseline_cov=Cx).fit_transform(X, y)
+    assert_true(np.sum(Xt ** 2) != 0)


### PR DESCRIPTION
Xdawn generates empty filters if there s a bad channels:

```
import numpy as np
from pyriemann.spatialfilters import Xdawn
X = np.random.rand(100, 30, 20)
y = np.random.randint(0, 2, 100)
X[:, 20:, :] = 0
Xdawn(estimator='oas').fit_transform(X, y)
```

This fixes it

(I also added some tests to the baseline covariance)