### PR TITLE
FIX: raises in CSP

### DIFF
--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -7,6 +7,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from .utils.covariance import _check_est
 from .utils.mean import mean_covariance
 from .utils.ajd import ajd_pham
+from .utils.distance import distance_methods
 
 
 class Xdawn(BaseEstimator, TransformerMixin):
@@ -189,8 +190,15 @@ class CSP(BaseEstimator, TransformerMixin):
 
     def __init__(self, nfilter=4, metric='euclid', log=True):
         """Init."""
+        if not isinstance(nfilter, int):
+            raise TypeError('nfilter must be an integer')
         self.nfilter = nfilter
+        if metric not in distance_methods.keys():
+            raise ValueError(
+                'metric must be in %s' % distance_methods.keys())
         self.metric = metric
+        if not isinstance(log, bool):
+            raise TypeError('log must be a boolean')
         self.log = log
 
     def fit(self, X, y):
@@ -210,6 +218,17 @@ class CSP(BaseEstimator, TransformerMixin):
         """
         Nt, Ne, Ns = X.shape
         classes = numpy.unique(y)
+        if not isinstance(X, (numpy.ndarray, list)):
+            raise TypeError('X must be an array.')
+        if not isinstance(y, (numpy.ndarray, list)):
+            raise TypeError('y must be an array.')
+        X, y = numpy.asarray(X), numpy.asarray(y)
+        if X.ndim != 3:
+            raise ValueError('X must be n_trials * n_channels * n_channels')
+        if len(y) != len(X):
+            raise ValueError('X and y must have the same length.')
+        if numpy.squeeze(y).ndim != 1:
+            raise ValueError('y must be of shape (n_trials,).')
 
         # estimate class means
         C = []
@@ -247,7 +266,7 @@ class CSP(BaseEstimator, TransformerMixin):
                 mutual_info.append(mi)
             ix = numpy.argsort(mutual_info)[::-1]
         else:
-            ValueError("Number of classes must be superior or equal at 2.")
+            raise ValueError("Number of classes must be >= 2.")
 
         # sort eigenvectors
         evecs = evecs[:, ix]

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from .utils.covariance import _check_est
 from .utils.mean import mean_covariance
 from .utils.ajd import ajd_pham
-from .utils.mean import mean_methods
+from .utils.mean import _check_mean_method
 
 
 class Xdawn(BaseEstimator, TransformerMixin):
@@ -193,9 +193,7 @@ class CSP(BaseEstimator, TransformerMixin):
         if not isinstance(nfilter, int):
             raise TypeError('nfilter must be an integer')
         self.nfilter = nfilter
-        if metric not in mean_methods.keys():
-            raise ValueError(
-                'metric must be in %s' % mean_methods.keys())
+        _check_mean_method(metric)
         self.metric = metric
         if not isinstance(log, bool):
             raise TypeError('log must be a boolean')

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from .utils.covariance import _check_est
 from .utils.mean import mean_covariance
 from .utils.ajd import ajd_pham
-from .utils.distance import distance_methods
+from .utils.mean import mean_methods
 
 
 class Xdawn(BaseEstimator, TransformerMixin):
@@ -193,9 +193,9 @@ class CSP(BaseEstimator, TransformerMixin):
         if not isinstance(nfilter, int):
             raise TypeError('nfilter must be an integer')
         self.nfilter = nfilter
-        if metric not in distance_methods.keys():
+        if metric not in mean_methods.keys():
             raise ValueError(
-                'metric must be in %s' % distance_methods.keys())
+                'metric must be in %s' % mean_methods.keys())
         self.metric = metric
         if not isinstance(log, bool):
             raise TypeError('log must be a boolean')

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -118,14 +118,6 @@ def distance(A, B, metric='riemann'):
     :returns: the distance between A and B
 
     """
-    distance_methods = {'riemann': distance_riemann,
-                        'logeuclid': distance_logeuclid,
-                        'euclid': distance_euclid,
-                        'logdet': distance_logdet,
-                        'kullback': distance_kullback,
-                        'kullback_right': distance_kullback_right,
-                        'kullback_sym': distance_kullback_sym,
-                        'wasserstein': distance_wasserstein}
     if callable(metric):
         distance_function = metric
     else:
@@ -139,3 +131,13 @@ def distance(A, B, metric='riemann'):
         d = distance_function(A, B)
 
     return d
+
+
+distance_methods = {'riemann': distance_riemann,
+                    'logeuclid': distance_logeuclid,
+                    'euclid': distance_euclid,
+                    'logdet': distance_logdet,
+                    'kullback': distance_kullback,
+                    'kullback_right': distance_kullback_right,
+                    'kullback_sym': distance_kullback_sym,
+                    'wasserstein': distance_wasserstein}

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -142,3 +142,15 @@ distance_methods = {'riemann': distance_riemann,
                     'kullback_right': distance_kullback_right,
                     'kullback_sym': distance_kullback_sym,
                     'wasserstein': distance_wasserstein}
+
+
+def _check_distance_method(method):
+    """checks methods """
+    if isinstance(method, str):
+        if method not in distance_methods.keys():
+            raise ValueError('Unknown mean method')
+        else:
+            method = distance_methods[method]
+    elif not hasattr(method, '__call__'):
+        raise ValueError('distance method must be a function or a string.')
+    return method

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -80,7 +80,7 @@ def distance_logdet(A, B):
     """Log-det distance between two covariance matrices A and B.
 
     .. math::
-            d = \sqrt{\left(\log(\det(\\frac{\mathbf{A}+\mathbf{B}}{2})) - 0.5 \\times \log(\det(\mathbf{A}) \det(\mathbf{B}))\\right)}
+            d = \sqrt{\left(\log(\det(\\frac{\mathbf{A}+\mathbf{B}}{2})) - 0.5 \\times \log(\det(\mathbf{A}) \det(\mathbf{B}))\\right)}  # noqa
 
     :param A: First covariance matrix
     :param B: Second covariance matrix
@@ -88,7 +88,8 @@ def distance_logdet(A, B):
 
     """
     return numpy.sqrt(numpy.log(numpy.linalg.det(
-        (A + B) / 2.0)) - 0.5 * numpy.log(numpy.linalg.det(A)*numpy.linalg.det(B)))
+        (A + B) / 2.0)) - 0.5 *
+        numpy.log(numpy.linalg.det(A)*numpy.linalg.det(B)))
 
 
 def distance_wasserstein(A, B):

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -343,3 +343,15 @@ mean_methods = {'riemann': mean_riemann,
                 'ale': mean_ale,
                 'harmonic': mean_harmonic,
                 'kullback_sym': mean_kullback_sym}
+
+
+def _check_mean_method(method):
+    """checks methods """
+    if isinstance(method, str):
+        if method not in mean_methods.keys():
+            raise ValueError('Unknown mean method')
+        else:
+            method = mean_methods[method]
+    elif not hasattr(method, '__call__'):
+        raise ValueError('mean method must be a function or a string.')
+    return method

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -28,7 +28,7 @@ def mean_riemann(covmats, tol=10e-9, maxiter=50, init=None,
     riemannian distance to the mean.
 
     .. math::
-            \mathbf{C} = \\arg\min{(\sum_i \delta_R ( \mathbf{C} , \mathbf{C}_i)^2)}
+            \mathbf{C} = \\arg\min{(\sum_i \delta_R ( \mathbf{C} , \mathbf{C}_i)^2)}  # noqa
 
     :param covmats: Covariance matrices set, Ntrials X Nchannels X Nchannels
     :param tol: the tolerance to stop the gradient descent
@@ -144,7 +144,7 @@ def mean_logdet(covmats, tol=10e-5, maxiter=50, init=None, sample_weight=None):
     This is an iterative procedure where the update is:
 
     .. math::
-            \mathbf{C} = \left(\sum_i \left( 0.5 \mathbf{C} + 0.5 \mathbf{C}_i \\right)^{-1} \\right)^{-1}
+            \mathbf{C} = \left(\sum_i \left( 0.5 \mathbf{C} + 0.5 \mathbf{C}_i \\right)^{-1} \\right)^{-1}  # noqa
 
     :param covmats: Covariance matrices set, Ntrials X Nchannels X Nchannels
     :param tol: the tolerance to stop the gradient descent
@@ -188,7 +188,7 @@ def mean_wasserstein(covmats, tol=10e-4, maxiter=50, init=None,
     This is an iterative procedure where the update is [1]:
 
     .. math::
-            \mathbf{K} = \left(\sum_i \left( \mathbf{K} \mathbf{C}_i \mathbf{K} \\right)^{1/2} \\right)^{1/2}
+            \mathbf{K} = \left(\sum_i \left( \mathbf{K} \mathbf{C}_i \mathbf{K} \\right)^{1/2} \\right)^{1/2}  # noqa
 
     with :math:`\mathbf{K} = \mathbf{C}^{1/2}`.
 
@@ -321,24 +321,25 @@ def mean_covariance(covmats, metric='riemann', sample_weight=None, *args):
 
 
     :param covmats: Covariance matrices set, Ntrials X Nchannels X Nchannels
-    :param metric: the metric (Default value 'riemann'), can be : 'riemann' , 'logeuclid' , 'euclid' , 'logdet', 'indentity', 'wasserstein', 'ale',
+    :param metric: the metric (Default value 'riemann'), can be : 'riemann' , 'logeuclid' , 'euclid' , 'logdet', 'indentity', 'wasserstein', 'ale',  # noqa
     'harmonic', 'kullback_sym' or a callable function
     :param sample_weight: the weight of each sample
     :param args: the argument passed to the sub function
     :returns: the mean covariance matrix
 
     """
-    options = {'riemann': mean_riemann,
-               'logeuclid': mean_logeuclid,
-               'euclid': mean_euclid,
-               'identity': mean_identity,
-               'logdet': mean_logdet,
-               'wasserstein': mean_wasserstein,
-               'ale': mean_ale,
-               'harmonic': mean_harmonic,
-               'kullback_sym': mean_kullback_sym}
     if callable(metric):
         C = metric(covmats, sample_weight=sample_weight, *args)
     else:
-        C = options[metric](covmats, sample_weight=sample_weight, *args)
+        C = mean_methods[metric](covmats, sample_weight=sample_weight, *args)
     return C
+
+mean_methods = {'riemann': mean_riemann,
+                'logeuclid': mean_logeuclid,
+                'euclid': mean_euclid,
+                'identity': mean_identity,
+                'logdet': mean_logdet,
+                'wasserstein': mean_wasserstein,
+                'ale': mean_ale,
+                'harmonic': mean_harmonic,
+                'kullback_sym': mean_kullback_sym}

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -1,5 +1,7 @@
 import numpy as np
-from pyriemann.spatialfilters import Xdawn
+from numpy.testing import assert_array_equal
+from nose.tools import assert_true, assert_raises
+from pyriemann.spatialfilters import Xdawn, CSP
 
 
 def test_Xdawn_init():
@@ -32,3 +34,38 @@ def test_Xdawn_baselinecov():
     xd = Xdawn(baseline_cov=baseline_cov)
     xd.fit(x, labels)
     xd.transform(x)
+
+
+def test_CSP():
+    """Test CSP"""
+    n_trials = 100
+    X = np.array([np.identity(3)] * n_trials)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
+
+    # Test Init
+    csp = CSP()
+    assert_true(csp.nfilter == 4)
+    assert_true(csp.metric == 'euclid')
+    assert_true(csp.log)
+    csp = CSP(3, 'riemann', False)
+    assert_true(csp.nfilter == 3)
+    assert_true(csp.metric == 'riemann')
+    assert_true(not csp.log)
+    assert_raises(TypeError, CSP, 'foo')
+    assert_raises(ValueError, CSP, metric='foo')
+
+    # Test fit
+    csp = CSP()
+    csp.fit(X, labels % 2)  # two classes
+    csp.fit(X, labels)  # 3 classes
+    assert_raises(ValueError, csp.fit, X, labels * 0.)  # 1 class
+    assert_raises(ValueError, csp.fit, X, labels[:1])  # unequal # of samples
+    assert_raises(TypeError, csp.fit, X, 'foo')
+    assert_array_equal(csp.filters_.shape, [X.shape[1], X.shape[1]])
+    assert_array_equal(csp.patterns_.shape, [X.shape[1], X.shape[1]])
+
+    # Test transform
+    Xt = csp.transform(X)
+    assert_array_equal(Xt.shape, [len(X), X.shape[1]])
+    assert_raises(TypeError, csp.transform, 'foo')
+    assert_raises(ValueError, csp.transform, X[:, 1:, :])  # unequal # of chans


### PR DESCRIPTION
There was a buggy raise when using less than 2 classes e.g. `CSP().fit(X, y=np.zeros(len(X)))`, so I added a series of tests.