### PR TITLE
FIX: decommented imports in __init__.py to make README example work

### DIFF
--- a/pyriemann/__init__.py
+++ b/pyriemann/__init__.py
@@ -1,7 +1,8 @@
-import classification
-import tangentspace
-import channelselection
-import estimation
-# import permutations
-import spatialfilters
-import clustering
+from . import classification
+from . import tangentspace
+from . import channelselection
+from . import estimation
+# from . import permutations
+from . import spatialfilters
+from . import clustering
+from . import stats

--- a/pyriemann/__init__.py
+++ b/pyriemann/__init__.py
@@ -1,6 +1,6 @@
-# import classification
-# import tangentspace
-# import channelselection
-# import estimation
+import classification
+import tangentspace
+import channelselection
+import estimation
 # import permutations
-# import spatialfilters
+import spatialfilters

--- a/pyriemann/__init__.py
+++ b/pyriemann/__init__.py
@@ -4,3 +4,4 @@ import channelselection
 import estimation
 # import permutations
 import spatialfilters
+import clustering


### PR DESCRIPTION
Currently, the example in the README file does not work because imports fail, due to issues in `pyriemann/__init__.py`. This little PR fixes that.