### PR TITLE
[MRG] Shrinkage Transformer

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,6 +18,7 @@ Covariance Estimation
     XdawnCovariances
     CospCovariances
     HankelCovariances
+    Shrinkage
 
 Classification
 ------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -14,6 +14,8 @@ v0.2.5 (Future release)
 
 - Support for python 3.4 in travis
 
+- Added Shrinkage transformer
+
 v0.2.4 (June 2016)
 -------------------
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -48,7 +48,7 @@ class Covariances(BaseEstimator, TransformerMixin):
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
             ndarray of trials.
-        y : ndarray shape (n_trials, 1)
+        y : ndarray shape (n_trials,)
             labels corresponding to each trial, not used.
 
         Returns
@@ -152,7 +152,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
             ndarray of trials.
-        y : ndarray shape (n_trials, 1)
+        y : ndarray shape (n_trials,)
             labels corresponding to each trial.
 
         Returns
@@ -225,7 +225,7 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
             ndarray of trials.
-        y : ndarray shape (n_trials, 1)
+        y : ndarray shape (n_trials,)
             labels corresponding to each trial.
 
         Returns
@@ -307,7 +307,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
             ndarray of trials.
-        y : ndarray shape (n_trials, 1)
+        y : ndarray shape (n_trials,)
             labels corresponding to each trial, not used.
 
         Returns
@@ -381,7 +381,7 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
             ndarray of trials.
-        y : ndarray shape (n_trials, 1)
+        y : ndarray shape (n_trials,)
             labels corresponding to each trial, not used.
 
         Returns
@@ -453,9 +453,9 @@ class Shrinkage(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
-            ndarray of trials.
-        y : ndarray shape (n_trials, 1)
-            labels corresponding to each trial, not used.
+            ndarray of Target data.
+        y : ndarray shape (n_trials,)
+            Labels corresponding to each trial, not used.
 
         Returns
         -------
@@ -480,7 +480,7 @@ class Shrinkage(BaseEstimator, TransformerMixin):
 
         covmats = numpy.zeros_like(X)
 
-        for i, x in enumerate(X):
-            covmats[i] = shrunk_covariance(x, self.shrinkage)
+        for ii, x in enumerate(X):
+            covmats[ii] = shrunk_covariance(x, self.shrinkage)
 
         return covmats

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -4,6 +4,7 @@ import numpy
 from .spatialfilters import Xdawn
 from .utils.covariance import covariances, covariances_EP, cospectrum
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.covariance import shrunk_covariance
 
 
 def _nextpow2(i):
@@ -418,4 +419,68 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
             X2.append(tmp)
         X2 = numpy.array(X2)
         covmats = covariances(X2, estimator=self.estimator)
+        return covmats
+
+
+class Shrinkage(BaseEstimator, TransformerMixin):
+
+    """Regularization of covariance matrices by shrinkage
+
+    This transformer apply a shrinkage regularization to any covariance matrix.
+    It directly use the `shrunk_covariance` function from scikit learn, applied
+    on each trial.
+
+    Parameters
+    ----------
+    shrinkage: float, (default, 0.1)
+        Coefficient in the convex combination used for the computation of the
+        shrunk estimate. must be between 0 and 1
+
+    Notes
+    -----
+    .. versionadded:: 0.2.5
+    """
+
+    def __init__(self, shrinkage=0.1):
+        """Init."""
+        self.shrinkage = shrinkage
+
+    def fit(self, X, y=None):
+        """Fit.
+
+        Do nothing. For compatibility purpose.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_trials, n_channels, n_samples)
+            ndarray of trials.
+        y : ndarray shape (n_trials, 1)
+            labels corresponding to each trial, not used.
+
+        Returns
+        -------
+        self : Shrinkage instance
+            The Shrinkage instance.
+        """
+        return self
+
+    def transform(self, X):
+        """Shrink and return the covariance matrices.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_trials, n_channels, n_channels)
+            ndarray of covariances matrices
+
+        Returns
+        -------
+        covmats : ndarray, shape (n_trials, n_channels, n_channels)
+            ndarray of covariance matrices for each trials.
+        """
+
+        covmats = numpy.zeros_like(X)
+
+        for i, x in enumerate(X):
+            covmats[i] = shrunk_covariance(x, self.shrinkage)
+
         return covmats

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pyriemann.estimation import (Covariances, ERPCovariances,
                                   XdawnCovariances, CospCovariances,
-                                  HankelCovariances)
+                                  HankelCovariances, Shrinkage)
 from nose.tools import assert_raises, assert_equal
 
 
@@ -63,3 +63,14 @@ def test_Cospcovariances():
     cov.fit_transform(x)
     assert_equal(cov.get_params(), dict(window=128, overlap=0.75, fmin=None,
                                         fmax=None, fs=None))
+
+
+def test_shrinkage():
+    """Test Shrinkage"""
+    x = np.random.randn(2, 3, 100)
+    cov = Covariances()
+    covs = cov.fit_transform(x)
+    sh = Shrinkage()
+    sh.fit(covs)
+    sh.transform(covs)
+    assert_equal(sh.get_params(), dict(shrinkage=0.1))


### PR DESCRIPTION
this transformer can be used to regularize covariance matrices post-estimation.
it's a standard shrinkage, and make use of the `shrunk_covariance` function from sklearn.

@kingjr : any comment ?