### PR TITLE
ENH: Explicit error as a consequence of non-spd matrices

### DIFF
--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -21,7 +21,7 @@ from mne.decoding import CSP
 
 # pyriemann import
 from pyriemann.classification import MDM, TSclassifier
-from pyriemann.estimation import covariances
+from pyriemann.estimation import Covariances
 
 # sklearn imports
 from sklearn.cross_validation import cross_val_score, KFold
@@ -65,7 +65,7 @@ cv = KFold(len(labels), 10, shuffle=True, random_state=42)
 epochs_data_train = 1e6*epochs.get_data()
 
 # compute covariance matrices
-cov_data_train = covariances(epochs_data_train)
+cov_data_train = Covariances().transform(epochs_data_train)
 
 ###############################################################################
 # Classification with Minimum distance to mean

--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -1,10 +1,14 @@
 import numpy
 import scipy
 
+from numpy.core.numerictypes import typecodes
+
 
 def _matrix_operator(Ci, operator):
     """matrix equivalent of an operator."""
-    eigvals, eigvects = scipy.linalg.eigh(Ci)
+    if Ci.dtype.char in typecodes['AllFloat'] and not numpy.isfinite(Ci).all():
+        raise ValueError("Covariance matrices must be positive definite. Add regularization to avoid this error.")
+    eigvals, eigvects = scipy.linalg.eigh(Ci, check_finite=False)
     eigvals = numpy.diag(operator(eigvals))
     Out = numpy.dot(numpy.dot(eigvects, eigvals), eigvects.T)
     return Out

--- a/tests/test_utils_base.py
+++ b/tests/test_utils_base.py
@@ -1,6 +1,7 @@
-from numpy.testing import assert_array_almost_equal
 import numpy as np
-
+from nose.tools import assert_raises
+from numpy.testing import assert_array_almost_equal
+from pyriemann.utils.mean import mean_riemann
 from pyriemann.utils.base import (sqrtm, invsqrtm, logm, expm, powm)
 
 
@@ -37,3 +38,11 @@ def test_powm():
     C = 2*np.eye(3)
     Ctrue = (2**0.5)*np.eye(3)
     assert_array_almost_equal(powm(C, 0.5), Ctrue)
+
+
+def test_check_raise():
+    """Test chech SPD matrices"""
+    C = 2*np.ones((10, 3, 3))
+    # This is an indirect check, the riemannian mean must crash when the
+    # matrices are not SPD.
+    assert_raises(ValueError, mean_riemann, C)


### PR DESCRIPTION
This is to fix #40 

i removed the check in the `scipy.linalg.eigh` function and did it myself with another error message.
this way, performances are not affected.