### PR TITLE
Add predict_proba function to potato

### DIFF
--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -370,6 +370,24 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         pred = z < self.threshold
         return pred
 
+    def predict_proba(self, X):
+        """predict artefact from data.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_trials, n_channels, n_channels)
+            ndarray of SPD matrices.
+
+        Returns
+        -------
+        pred : ndarray of float, shape (n_epochs, 1)
+            the artefact detection. 0.0 if the trial is clean, and 1.0 if
+            the trial contain an artefact.
+        """
+        z = self.transform(X)
+        pred = 0.0 if z < self.threshold else 1.0
+        return pred
+
     def _get_z_score(self, d):
         """get z score from distance."""
         z = (d - self._mean) / self._std

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -79,8 +79,11 @@ def test_Potato_init():
     # transform
     pt.transform(covset)
 
-    # transform
+    # predict
     pt.predict(covset)
+
+    # predict_proba
+    pt.predict_proba(covset)
 
     # lower threshold
     pt = Potato(threshold=1)


### PR DESCRIPTION
Add: `predict_proba` to `Potato`. 

`0.0` if the trial is clean, and `1.0` if the trial contains an artifact
