### PR TITLE
Avoid joblib warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
   apt:
     packages:
       - libatlas-dev
-      - libatlas3gf-base
+      - libatlas3-base
       - libblas-dev
       - liblapack-dev
       - python-matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: python
-env:
-    - PYTHON=2.7
-    - PYTHON=3.5
-# command to install dependencies\
-cache: pip
-sudo: false
-virtualenv:
-  system_site_packages: true
+python:
+    - '2.7'
+    - '3.5'
+
+# command to install dependencies
 addons:
   apt:
     packages:
@@ -14,27 +11,16 @@ addons:
       - libatlas3-base
       - libblas-dev
       - liblapack-dev
-      - python-matplotlib
       - gfortran
-      - python-tk
-install:
-  - conda create -n testenv --yes pip python=$PYTHON
-  - source activate testenv
-  - conda install --yes --quiet numpy scipy scikit-learn seaborn six pandas nose coverage
-  - pip install codecov
-  - python setup.py build install
 
-# Setup anaconda
+install:
+  - pip install -r requirements.txt
+  - pip install nose coverage codecov
+
 before_install:
-  - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p /home/travis/miniconda
-  - export PATH=/home/travis/miniconda/bin:$PATH
-  - conda update --yes --quiet conda
   # We need to create a (fake) display on Travis (allows Mayavi tests to run)
   - export DISPLAY=:99.0
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset
-
 
 # command to run tests
 script: nosetests  --with-coverage --cover-package=pyriemann

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -3,8 +3,7 @@ import numpy
 from sklearn.base import (BaseEstimator, ClassifierMixin, TransformerMixin,
                           ClusterMixin)
 from sklearn.cluster.k_means_ import _init_centroids
-from sklearn.externals.joblib import Parallel
-from sklearn.externals.joblib import delayed
+from joblib import Parallel, delayed
 
 from .classification import MDM
 


### PR DESCRIPTION
Replace the `from sklearn.externals.joblib import ...` into `from joblib import ...` to avoid the following warning (that will eventually turn into an error with sklearn==0.23):
```
sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.
```