### PR TITLE
fix: added workaround for sklearn 0.24

### DIFF
--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -2,7 +2,25 @@
 import numpy
 from sklearn.base import (BaseEstimator, ClassifierMixin, TransformerMixin,
                           ClusterMixin)
-from sklearn.cluster._kmeans import _init_centroids
+
+try:
+    from sklearn.cluster._kmeans import _init_centroids
+except ImportError:
+    # Workaround for scikit-learn v0.24.0rc1+
+    # See issue: https://github.com/alexandrebarachant/pyRiemann/issues/92
+    from sklearn.cluster import KMeans
+
+    def _init_centroids(X, n_clusters, init, random_state, x_squared_norms):
+        if random_state is not None:
+            random_state = numpy.random.RandomState(random_state)
+        return KMeans(n_clusters=n_clusters)._init_centroids(
+            X,
+            x_squared_norms,
+            init,
+            random_state,
+        )
+
+
 from joblib import Parallel, delayed
 
 from .classification import MDM


### PR DESCRIPTION
Fixes #87, fixes #92

This change also fixes decent Python 3.9 support (since sklearn 0.24 is the first version to include wheels for Python 3.9)