### PR TITLE
fix for new sklearn version

### DIFF
--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -2,7 +2,7 @@
 import numpy
 from sklearn.base import (BaseEstimator, ClassifierMixin, TransformerMixin,
                           ClusterMixin)
-from sklearn.cluster._kmeans import _init_centroids
+from sklearn.cluster._kmeans import KMeans, check_random_state
 from joblib import Parallel, delayed
 
 from .classification import MDM
@@ -16,7 +16,8 @@ def _fit_single(X, y=None, n_clusters=2, init='random', random_state=None,
     # init random state if provided
     mdm = MDM(metric=metric, n_jobs=n_jobs)
     squared_nomrs = [numpy.linalg.norm(x, ord='fro')**2 for x in X]
-    mdm.covmeans_ = _init_centroids(X, n_clusters, init,
+    random_state = check_random_state(random_state)
+    mdm.covmeans_ = KMeans(n_clusters=n_clusters)._init_centroids(X=X, init=init,
                                     random_state=random_state,
                                     x_squared_norms=squared_nomrs)
     if y is not None:


### PR DESCRIPTION
sklearn 0.24 changed the KMeans class, making the _init_centroinds method a class method.